### PR TITLE
Add Expo React Native template with Supabase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.expo/
+.expo-shared/
+.DS_Store
+npm-debug.log*

--- a/App.js
+++ b/App.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { StyleSheet, View, Text } from 'react-native';
+import 'react-native-url-polyfill/auto';
+import { supabase } from './supabaseClient';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text>Hello World!</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# Polaris_early
+# Polaris Early Expo App
+
+This is a minimal [Expo](https://expo.dev/) React Native project that uses [Supabase](https://supabase.com/) and displays **Hello World!** when the app starts.
+
+## Setup
+
+1. Install dependencies:
+   ```sh
+   npm install
+   ```
+
+2. Set your Supabase credentials in `supabaseClient.js`:
+   ```js
+   const supabaseUrl = 'https://YOUR-SUPABASE-URL.supabase.co';
+   const supabaseAnonKey = 'YOUR-SUPABASE-ANON-KEY';
+   ```
+
+3. Start the Expo development server:
+   ```sh
+   npm start
+   ```
+
+Then open the project in the Expo Go app on iOS or an emulator.

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "polaris_early_expo",
+  "version": "1.0.0",
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.38.5",
+    "expo": "~49.0.0",
+    "expo-status-bar": "~1.6.0",
+    "react": "18.2.0",
+    "react-native": "0.72.4"
+  }
+}

--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -1,0 +1,7 @@
+import { createClient } from '@supabase/supabase-js';
+
+// Replace with your Supabase credentials
+const supabaseUrl = 'https://YOUR-SUPABASE-URL.supabase.co';
+const supabaseAnonKey = 'YOUR-SUPABASE-ANON-KEY';
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- initialize an Expo project skeleton
- set up Supabase client with placeholders
- render "Hello World!" on app load
- document project setup steps

## Testing
- `npm install` *(fails: connect EHOSTUNREACH)*