### PR TITLE
Add Expo SDK 53 setup

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,9 +1,14 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { StyleSheet, View, Text } from 'react-native';
 import 'react-native-url-polyfill/auto';
 import { supabase } from './supabaseClient';
 
 export default function App() {
+  useEffect(() => {
+    // Example call to ensure Supabase client works
+    supabase.auth.getSession().catch(console.error);
+  }, []);
+
   return (
     <View style={styles.container}>
       <Text>Hello World!</Text>

--- a/README.md
+++ b/README.md
@@ -1,23 +1,28 @@
 # Polaris Early Expo App
 
-This is a minimal [Expo](https://expo.dev/) React Native project that uses [Supabase](https://supabase.com/) and displays **Hello World!** when the app starts.
+This is a minimal [Expo](https://expo.dev/) React Native project that uses [Supabase](https://supabase.com/) and displays **Hello World!** when the app starts. It targets **Expo SDK 53** so it can be opened with the Expo Go app on your iPhone.
 
 ## Setup
 
-1. Install dependencies:
+1. Install the Expo CLI if you don't have it:
+   ```sh
+   npm install -g expo-cli
+   ```
+
+2. Install project dependencies:
    ```sh
    npm install
    ```
 
-2. Set your Supabase credentials in `supabaseClient.js`:
+3. Set your Supabase credentials in `supabaseClient.js`:
    ```js
    const supabaseUrl = 'https://YOUR-SUPABASE-URL.supabase.co';
    const supabaseAnonKey = 'YOUR-SUPABASE-ANON-KEY';
    ```
 
-3. Start the Expo development server:
+4. Start the Expo development server:
    ```sh
    npm start
    ```
 
-Then open the project in the Expo Go app on iOS or an emulator.
+Scan the QR code printed in the terminal with the Expo Go app on your iPhone to open the project.

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.38.5",
-    "expo": "~49.0.0",
+    "expo": "~53.0.0",
     "expo-status-bar": "~1.6.0",
     "react": "18.2.0",
-    "react-native": "0.72.4"
+    "react-native": "0.73.0"
   }
 }


### PR DESCRIPTION
## Summary
- upgrade to Expo SDK 53
- note iOS setup in README
- add a simple Supabase call in the hello world page

## Testing
- `npm test` *(fails: Missing script)*